### PR TITLE
Fixes #19014: Add requirements.txt for rudder-api-client repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Installation
 ------------
 This is a preview code, you need to install it from github at the moment.
 
-Dependencies: requests, urllib3 and docopt. It should work with python2 and python3.
+    pip install -r requirements.txt
 
 Clone the repository, then run:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+certifi==2020.12.5
+chardet==4.0.0
+docopt==0.6.2
+idna==2.10
+requests==2.25.1
+urllib3==1.26.3


### PR DESCRIPTION
Currently the installation documentation is not great, for the sake of compatibility, it is better to "freeze" the dependencies and store them in a requirements.txt file for an easier installation.